### PR TITLE
Update events.inc.php

### DIFF
--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -114,7 +114,7 @@ SELECT id, name
       'author' =>             $picture['current']['author'],
       'level' =>              $picture['current']['level'],
       'date_creation' =>      substr($picture['current']['date_creation'], 0, 10),
-      'date_creation_time' => substr($picture['current']['date_creation'], 11, 5),
+      'date_creation_time' => substr($picture['current']['date_creation'], 11, 8),
       'tag_selection' =>      $tag_selection,
       );
   }


### PR DESCRIPTION
This change is resolving an issue when you _Quick edit_ some picture and save it and you have another picture taken in the same minute, then it could change the order of those pictures by cutting off the seconds portion from the time.

Substring takes only hours and minuntes and trim off seconds.
Value `date_creation_time` contains only `hh:mm`.
With this change it will contains `hh:mm:ss` and will not cut off secontds from the time.