### PR TITLE
In Quick Edit, do not ommit seconds

### DIFF
--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -115,7 +115,7 @@ SELECT id, name
       'author' =>             $picture['current']['author'],
       'level' =>              $picture['current']['level'],
       'date_creation' =>      substr($picture['current']['date_creation'], 0, 10),
-      'date_creation_time' => substr($picture['current']['date_creation'], 11, 5),
+      'date_creation_time' => substr($picture['current']['date_creation'], 11, 8),
       'tag_selection' =>      $tag_selection,
       );
   }


### PR DESCRIPTION
While Quick Editing, seconds were cut off and lost in date_creation_time. This had impact on the sorting if had a few more images taken within the same second.